### PR TITLE
fix bug when decode engine info

### DIFF
--- a/cmd/node/node.go
+++ b/cmd/node/node.go
@@ -1,10 +1,11 @@
 package node
 
 import (
+	"encoding/json"
+
 	"github.com/projecteru2/resource-storage/cmd"
 	"github.com/projecteru2/resource-storage/storage"
 
-	"github.com/mitchellh/mapstructure"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/resource/plugins/binary"
 	resourcetypes "github.com/projecteru2/core/resource/types"
@@ -35,9 +36,13 @@ func addNode(c *cli.Context) error {
 			return nil, types.ErrEmptyNodeName
 		}
 		engineInfo := in.RawParams("info")
+		eInfoBytes, err := json.Marshal(engineInfo)
+		if err != nil {
+			return nil, err
+		}
 		resource := in.RawParams("resource")
 		info := &enginetypes.Info{}
-		if err := mapstructure.Decode(engineInfo, info); err != nil {
+		if err := json.Unmarshal(eInfoBytes, info); err != nil {
 			return nil, err
 		}
 		return s.AddNode(c.Context, nodename, resource, info)


### PR DESCRIPTION
`[]byte` will become string after json Marshal and Unmarshal, so mapstructure can't decode `map[string][]byte` here.